### PR TITLE
Fix + extra information

### DIFF
--- a/src/main/java/InstallerFrame.java
+++ b/src/main/java/InstallerFrame.java
@@ -230,18 +230,15 @@ public class InstallerFrame extends JFrame {
         try {
             URL downloadUrl = getDownloadUrl(version);
             if (downloadUrl != null) {
-                System.out.println("DWONALODAING "+downloadUrl+" as "+downloadUrl.toString().split("/")[downloadUrl.toString().split("/").length-1]+" "+destinationFolder);
+                System.out.println("DWONALODAING "+downloadUrl);
                 String fileName = downloadUrl.toString().split("/")[downloadUrl.toString().split("/").length-1];
                 Path destinationPath = destinationFolder.toPath().resolve(fileName);
-                Files.createDirectories(destinationFolder.toPath());
                 Files.copy(downloadUrl.openStream(), destinationPath, StandardCopyOption.REPLACE_EXISTING);
-
                 showMessage("Installation successful!");
             } else {
                 showMessage("Failed to get download URL. Installation aborted.");
             }
         } catch (IOException e) {
-            e.printStackTrace();
             showMessage("Error copying file: " + e.getMessage());
         }
     }
@@ -279,9 +276,9 @@ public class InstallerFrame extends JFrame {
     private File getDefaultFolder(String option, String userHome) {
         switch (option) {
             case "Feather":
-                return new File(userHome + "\\AppData\\Roaming\\.feather\\user-mods\\1.8.9");
+                return new File(userHome + "\\.feather\\user-mods\\1.8.9");
             case "Forge":
-                return new File(userHome + "\\AppData\\Roaming\\.minecraft\\mods");
+                return new File(userHome + "\\.minecraft\\mods");
             case "Custom":
                 JFileChooser fileChooser = new JFileChooser(userHome);
                 fileChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);

--- a/src/main/java/mrfast/sbf/SkyblockFeatures.java
+++ b/src/main/java/mrfast/sbf/SkyblockFeatures.java
@@ -252,6 +252,7 @@ public class SkyblockFeatures {
         commands.add(new FlipsCommand());
         commands.add(new DungeonsCommand());
         commands.add(new RepartyCommand());
+        commands.add(new DungeonPlayerInfoCommand());
         commands.add(new PingCommand());
         commands.add(new FakePlayerCommand());
         commands.add(new pvCommand());

--- a/src/main/java/mrfast/sbf/commands/DungeonPlayerInfoCommand.java
+++ b/src/main/java/mrfast/sbf/commands/DungeonPlayerInfoCommand.java
@@ -27,7 +27,7 @@ public class DungeonPlayerInfoCommand  extends  CommandBase{
     @Override
     public void processCommand(ICommandSender arg0, String[] arg1) throws CommandException {
         PartyFinderFeatures instance = new PartyFinderFeatures();
-        if(arg1.length == 0) instance.showDungeonPlayerInfo(Minecraft.getMinecraft().thePlayer.getName());
-        if(arg1.length ==1) instance.showDungeonPlayerInfo(arg1[0]);
+        if(arg1.length == 0) instance.showDungeonPlayerInfo(Minecraft.getMinecraft().thePlayer.getName(),false);
+        if(arg1.length ==1) instance.showDungeonPlayerInfo(arg1[0],false);
     }
 }

--- a/src/main/java/mrfast/sbf/commands/DungeonPlayerInfoCommand.java
+++ b/src/main/java/mrfast/sbf/commands/DungeonPlayerInfoCommand.java
@@ -1,0 +1,33 @@
+package mrfast.sbf.commands;
+
+import mrfast.sbf.features.dungeons.PartyFinderFeatures;
+import net.minecraft.client.Minecraft;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+
+
+public class DungeonPlayerInfoCommand  extends  CommandBase{
+    @Override
+    public String getCommandName() {
+        return "sfcata";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender arg0) {
+        return "/" + getCommandName() + " [name]";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+
+    @Override
+    public void processCommand(ICommandSender arg0, String[] arg1) throws CommandException {
+        PartyFinderFeatures instance = new PartyFinderFeatures();
+        if(arg1.length == 0) instance.showDungeonPlayerInfo(Minecraft.getMinecraft().thePlayer.getName());
+        if(arg1.length ==1) instance.showDungeonPlayerInfo(arg1[0]);
+    }
+}

--- a/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
+++ b/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
@@ -109,7 +109,7 @@ public class PartyFinderFeatures {
         if(partyFinderJoin && SkyblockFeatures.config.partyFinderJoinMessages) {
             String playerName = Utils.cleanColor(message.split(" ")[3]);
             if(playerName.contains(Minecraft.getMinecraft().thePlayer.getName())) return;
-            showDungeonPlayerInfo(playerName);
+            showDungeonPlayerInfo(playerName,true);
         }
         if(!SkyblockFeatures.config.dungeonPartyDisplay) return;
 

--- a/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
+++ b/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
@@ -108,6 +108,7 @@ public class PartyFinderFeatures {
         boolean partyFinderJoin = message.startsWith("Party Finder > ") && message.contains(" joined the dungeon group! (");
         if(partyFinderJoin && SkyblockFeatures.config.partyFinderJoinMessages) {
             String playerName = Utils.cleanColor(message.split(" ")[3]);
+            if(playerName.contains(Minecraft.getMinecraft().thePlayer.getName())) return;
             showDungeonPlayerInfo(playerName);
         }
         if(!SkyblockFeatures.config.dungeonPartyDisplay) return;

--- a/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
+++ b/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
@@ -142,7 +142,7 @@ public class PartyFinderFeatures {
         new Thread(() -> {
             // Get UUID for Hypixel API requests
             String uuid = NetworkUtils.getUUID(name);
-
+            if (uuid == null) return;
             // Find stats of latest profile
             String latestProfile = NetworkUtils.getLatestProfileID(uuid);
             if (latestProfile == null) return;

--- a/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
+++ b/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
@@ -138,7 +138,7 @@ public class PartyFinderFeatures {
         }
     }
 
-    public void showDungeonPlayerInfo(String name) {
+    public void showDungeonPlayerInfo(String name,Boolean showKick) {
         new Thread(() -> {
             // Get UUID for Hypixel API requests
             String uuid = NetworkUtils.getUUID(name);
@@ -273,7 +273,7 @@ public class PartyFinderFeatures {
                 armourStream.close();
 
                 ChatComponentText nameComponent = new ChatComponentText(ChatFormatting.AQUA+" Data For: " +ChatFormatting.YELLOW+ name + "\n ");
-                ChatComponentText kickComponent = new ChatComponentText("\n"+ChatFormatting.GREEN+"Click here to remove "+ChatFormatting.LIGHT_PURPLE+name+ChatFormatting.GREEN+" from the party");
+                ChatComponentText kickComponent = new ChatComponentText(showKick?"\n"+ChatFormatting.GREEN+"Click here to remove "+ChatFormatting.LIGHT_PURPLE+name+ChatFormatting.GREEN+" from the party":"");
                 ChatComponentText weaponComponent = new ChatComponentText(ChatFormatting.DARK_AQUA + weapon + "\n ");
                 ChatComponentText helmetComponent = new ChatComponentText(" "+ChatFormatting.DARK_AQUA + helmet + "\n ");
                 ChatComponentText chestComponent = new ChatComponentText(ChatFormatting.DARK_AQUA + chest + "\n ");
@@ -284,8 +284,10 @@ public class PartyFinderFeatures {
                 helmetComponent.setChatStyle(helmetComponent.getChatStyle().setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(helmetLore))));
                 chestComponent.setChatStyle(chestComponent.getChatStyle().setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(chestLore))));
                 legComponent.setChatStyle(legComponent.getChatStyle().setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(legsLore))));
+                if(showKick) {
                 kickComponent.setChatStyle(kickComponent.getChatStyle().setChatClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND,"/p kick "+name)));
                 kickComponent.setChatStyle(kickComponent.getChatStyle().setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,new ChatComponentText(ChatFormatting.YELLOW+"/p kick "+name))));
+                }
 
                 bootComponent.setChatStyle(bootComponent.getChatStyle().setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(bootsLore))));
 
@@ -314,7 +316,6 @@ public class PartyFinderFeatures {
                 JsonObject masterCompletionObj = masterCatacombsObject.get("tier_completions").getAsJsonObject();
                 int totalMasterRuns = 1;
                 for (int i = 1; i <= highestMasterFloor; i++) {
-                    System.out.println(i);
                     masterCompletionsHoverString
                             .append(ChatFormatting.RED)
                             .append(i == 0 ? "Entrance: " : "Master Floor " + i + ": ")

--- a/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
+++ b/src/main/java/mrfast/sbf/features/dungeons/PartyFinderFeatures.java
@@ -299,7 +299,7 @@ public class PartyFinderFeatures {
                             .append(i == 0 ? "Entrance: " : "Floor " + i + ": ")
                             .append(ChatFormatting.YELLOW)
                             .append(completionObj.get(String.valueOf(i)).getAsInt())
-                            .append(i < highestCatacombsFloor ? "\n": "");
+                            .append("\n");
 
                     totalRuns = totalRuns + completionObj.get(String.valueOf(i)).getAsInt();
                 }
@@ -316,11 +316,11 @@ public class PartyFinderFeatures {
                 for (int i = 1; i <= highestMasterFloor; i++) {
                     System.out.println(i);
                     masterCompletionsHoverString
-                            .append(ChatFormatting.AQUA)
+                            .append(ChatFormatting.RED)
                             .append(i == 0 ? "Entrance: " : "Master Floor " + i + ": ")
                             .append(ChatFormatting.YELLOW)
                             .append(masterCompletionObj.get(String.valueOf(i)).getAsInt())
-                            .append(i < highestCatacombsFloor ? "\n": "");
+                            .append("\n");
 
                     totalMasterRuns = totalMasterRuns +  masterCompletionObj.get(String.valueOf(i)).getAsInt();
                 }

--- a/src/main/java/mrfast/sbf/gui/ProfileViewerGui.java
+++ b/src/main/java/mrfast/sbf/gui/ProfileViewerGui.java
@@ -1512,8 +1512,11 @@ public class ProfileViewerGui extends WindowScreen {
                 JsonObject miningCore = ProfilePlayerResponse.get("mining_core").getAsJsonObject();
 
                 int hotmExperience = Utils.safeGetInt(miningCore, "experience");
-                int mithrilPowder = Utils.safeGetInt(miningCore, "powder_mithril");
-                int gemstonePowder = Utils.safeGetInt(miningCore, "powder_gemstone");
+                int mithrilPowderAvailable = Utils.safeGetInt(miningCore, "powder_mithril");
+                int mithrilPowderSpent = Utils.safeGetInt(miningCore, "powder_spent_mithril");
+                int gemstonePowderAvailable = Utils.safeGetInt(miningCore, "powder_gemstone");
+                int gemstonePowderSpent = Utils.safeGetInt(miningCore, "powder_spent_gemstone");
+
 
 
                 JsonArray tutorial = ProfilePlayerResponse.get("tutorial").getAsJsonArray();
@@ -1561,8 +1564,8 @@ public class ProfileViewerGui extends WindowScreen {
                 new UIText(g + "Tier: " + bold + hotmTier + "/7").setY(new SiblingConstraint(2f)).setChildOf(left);
                 new UIText(g + "Token Of The Mountain: " + bold + (tokensSpent) + "/17").setY(new SiblingConstraint(2f)).setChildOf(left);
                 new UIText(g + "Peak Of The Mountain: " + bold + potm + "/7").setY(new SiblingConstraint(2f)).setChildOf(left);
-                new UIText(g + "Mithril Powder: " + ChatFormatting.DARK_GREEN + ChatFormatting.BOLD + nf.format(mithrilPowder)).setY(new SiblingConstraint(2f)).setChildOf(left);
-                new UIText(g + "Gemstone Powder: " + ChatFormatting.LIGHT_PURPLE + ChatFormatting.BOLD + nf.format(gemstonePowder)).setY(new SiblingConstraint(2f)).setChildOf(left);
+                new UIText(g + "Mithril Powder: " + ChatFormatting.DARK_GREEN + ChatFormatting.BOLD + nf.format(mithrilPowderAvailable) + "/" + nf.format(mithrilPowderAvailable + mithrilPowderSpent)).setY(new SiblingConstraint(2f)).setChildOf(left);
+                new UIText(g + "Gemstone Powder: " + ChatFormatting.LIGHT_PURPLE + ChatFormatting.BOLD + nf.format(gemstonePowderAvailable) + "/" + nf.format(gemstonePowderAvailable + gemstonePowderSpent)).setY(new SiblingConstraint(2f)).setChildOf(left);
 
                 String pickaxeAbility = "None";
                 try {

--- a/src/main/java/mrfast/sbf/gui/ProfileViewerGui.java
+++ b/src/main/java/mrfast/sbf/gui/ProfileViewerGui.java
@@ -1144,6 +1144,20 @@ public class ProfileViewerGui extends WindowScreen {
                     InventoryBasic wardrobePage1 = new InventoryBasic("Test#1", true, 36);
                     InventoryBasic wardrobePage2 = new InventoryBasic("Test#1", true, 36);
 
+                    InventoryBasic vault = new InventoryBasic("Test#1", true, 27);
+                    if (ProfilePlayerResponse.has("personal_vault_contents")){
+                        String inventoryBase64 = ProfilePlayerResponse.get("personal_vault_contents").getAsJsonObject().get("data").getAsString();
+                        Inventory items = new Inventory(inventoryBase64);
+                        List<ItemStack> a = ItemUtils.decodeInventory(items, true);
+
+                        int index = 0;
+                        for (ItemStack item : a) {
+                            vault.setInventorySlotContents(index, item);
+                            index++;
+                        }
+
+                    }
+
                     if (ProfilePlayerResponse.has("wardrobe_contents")) {
                         String inventoryBase64 = ProfilePlayerResponse.get("wardrobe_contents").getAsJsonObject().get("data").getAsString();
                         Inventory items = new Inventory(inventoryBase64);
@@ -1165,9 +1179,10 @@ public class ProfileViewerGui extends WindowScreen {
 
                     UIComponent container = new UIBlock(clear)
                             .setWidth(new RelativeConstraint(1f))
-                            .setY(new SiblingConstraint(10f))
+                            .setX(new PixelConstraint(0f))
+                            .setY(new SiblingConstraint(5f))
                             .setChildOf(statsAreaContainer)
-                            .setHeight(new RelativeConstraint(0.25f));
+                            .setHeight(new RelativeConstraint(0.33f));
 
                     new InventoryComponent(inv, "Inventory")
                             .setChildOf(container)
@@ -1178,6 +1193,11 @@ public class ProfileViewerGui extends WindowScreen {
                     new InventoryComponent(wardrobePage2, "Wardrobe Page 2")
                             .setX(new SiblingConstraint(10f))
                             .setChildOf(container);
+
+                    new InventoryComponent(vault, "Personal Vault")
+                            .setChildOf(container)
+                            .setX(new PixelConstraint(0f))
+                            .setY(new SiblingConstraint(10f));
                 }
 
                 { // Talisman Bag, 3 pages

--- a/src/main/java/mrfast/sbf/gui/ProfileViewerUtils.java
+++ b/src/main/java/mrfast/sbf/gui/ProfileViewerUtils.java
@@ -291,11 +291,11 @@ public class ProfileViewerUtils {
         Map<Integer, Integer> hotmXp = new HashMap<>();
         hotmXp.put(1, 0);
         hotmXp.put(2, 3000);
-        hotmXp.put(3, 9000);
-        hotmXp.put(4, 25000);
-        hotmXp.put(5, 60000);
-        hotmXp.put(6, 100000);
-        hotmXp.put(7, 150000);
+        hotmXp.put(3, 12000);
+        hotmXp.put(4, 37000);
+        hotmXp.put(5, 97000);
+        hotmXp.put(6, 197000);
+        hotmXp.put(7, 347000);
 
         return determineLevel(hotmXp, xp);
     }


### PR DESCRIPTION
## Created:
- `\sfcata [name]`: gets the dungeon player info

## Added:
- Watcher kills to dungeon info
- Mastermode to dungeon info
- Personal vault to `/sfpv`
- Improved secret/run by including mastermode runs
- Added all the collected mithril/gemstone powder

## Fixed
- Joining party shows your own data
-  Not showing correct hotm level in `\sfpv`

### Not related
the edit in Installerframe was an oopsie